### PR TITLE
Update rxjs to version 7.0.0

### DIFF
--- a/e2e/stories/dataset/aggregations.e2e.ts
+++ b/e2e/stories/dataset/aggregations.e2e.ts
@@ -1,3 +1,4 @@
+import { lastValueFrom } from 'rxjs';
 import { ISetField } from "../../management";
 import { cleaning, DEFAULT_DATASET, dom, init } from "../../teardowns";
 
@@ -21,7 +22,7 @@ const data = [
 describe("Dataset aggregation functions", () => {
   beforeAll(async () => {
     await init(DEFAULT_DATASET.NAME, fields);
-    await dom.dataset(DEFAULT_DATASET.NAME).insert(data).toPromise();
+    await lastValueFrom(dom.dataset(DEFAULT_DATASET.NAME).insert(data));
   });
 
   afterAll(async () => cleaning());

--- a/e2e/stories/dataset/output-record.e2e.ts
+++ b/e2e/stories/dataset/output-record.e2e.ts
@@ -1,3 +1,4 @@
+import { lastValueFrom } from 'rxjs';
 import * as faker from "faker";
 import * as Joi from "joi";
 import { Dataset } from "../../../src/api/dataops/dataset";
@@ -60,9 +61,8 @@ describe("output record fields REST API", () => {
       ],
     );
     dataset = dom.dataset(DEFAULT_DATASET.NAME);
-    await dataset
-      .insert(testData)
-      .toPromise();
+    await lastValueFrom(dataset
+      .insert(testData));
   });
 
   afterAll(async () => cleaning());

--- a/e2e/stories/jfs/jfs-delete.e2e.ts
+++ b/e2e/stories/jfs/jfs-delete.e2e.ts
@@ -1,3 +1,4 @@
+import { lastValueFrom } from 'rxjs';
 import * as faker from "faker";
 import * as Joi from "joi";
 import { field } from "../../../src";
@@ -21,23 +22,20 @@ describe("delete record REST API", async () => {
   afterAll(async () => cleaning());
 
   it("deletes single record by id", async () => {
-    const record = await fileset
+    const record = await lastValueFrom(fileset
       .upload([{
         data: { [DEFAULT_FILESET.FIELD]: faker.random.word() },
-      }])
-      .toPromise();
+      }]));
 
     const isRecord = field("id").isEqualTo(record.id);
 
-    await fileset
+    await lastValueFrom(fileset
       .delete()
-      .where(isRecord)
-      .toPromise();
+      .where(isRecord));
 
-    const result = fileset
+    const result = lastValueFrom(fileset
       .select()
-      .where(isRecord)
-      .toPromise();
+      .where(isRecord));
 
     joiAssert(result, Joi.empty());
   });
@@ -56,15 +54,13 @@ describe("delete record REST API", async () => {
     it("should delete all records by ids list", async () => {
       const isInList = field("id").isInArray(records.map(({ id }) => id));
 
-      await fileset
+      await lastValueFrom(fileset
         .delete()
-        .where(isInList)
-        .toPromise();
+        .where(isInList));
 
-      const result = fileset
+      const result = lastValueFrom(fileset
         .select()
-        .where(isInList)
-        .toPromise();
+        .where(isInList));
 
       joiAssert(result, Joi.empty());
     });
@@ -72,10 +68,9 @@ describe("delete record REST API", async () => {
 
   it("should throw error under invalid where condition", async () => {
     try {
-      await fileset
+      await lastValueFrom(fileset
         .delete()
-        .where(field("id").isEqualTo(faker.random.uuid()))
-        .toPromise();
+        .where(field("id").isEqualTo(faker.random.uuid())));
     } catch (e) {
       joiAssert(e, BackendErrorSchema);
     }

--- a/e2e/stories/jfs/jfs-select.e2e.ts
+++ b/e2e/stories/jfs/jfs-select.e2e.ts
@@ -1,3 +1,4 @@
+import { lastValueFrom } from 'rxjs';
 import * as faker from "faker";
 import * as Joi from "joi";
 import { field } from "../../../src";
@@ -25,10 +26,9 @@ describe("filter records REST API", () => {
 
   function testLength(title: string, condition: Condition, expectedLength: number) {
     it(`should select records by "${title}"`, async () => {
-      const selectResult = await fileset
+      const selectResult = await lastValueFrom(fileset
         .select()
-        .where(condition)
-        .toPromise();
+        .where(condition));
 
       expect(selectResult.length).toEqual(expectedLength);
     });
@@ -37,10 +37,9 @@ describe("filter records REST API", () => {
   function testError(title: string, condition: Condition) {
     it(`should throw error when selecting records by "${title}"`, async () => {
       try {
-        await fileset
+        await lastValueFrom(fileset
           .select()
-          .where(condition)
-          .toPromise();
+          .where(condition));
       } catch (e) {
         joiAssert(e, BackendErrorSchema);
       }
@@ -48,16 +47,14 @@ describe("filter records REST API", () => {
   }
 
   function setupData(testData: Array<{ data: any }>) {
-    return fileset
-      .upload(testData)
-      .toPromise();
+    return lastValueFrom(fileset
+      .upload(testData));
   }
 
   function clearData() {
-    return fileset
+    return lastValueFrom(fileset
       .delete()
-      .where(field("id").isNotNull())
-      .toPromise();
+      .where(field("id").isNotNull()));
   }
 
   function test(
@@ -415,30 +412,27 @@ describe("filter records REST API", () => {
     afterAll(async () => await clearData());
 
     it("should return less items when limit is lower than total of results", async () => {
-      const result = await fileset
+      const result = await lastValueFrom(fileset
         .select()
-        .limit(2)
-        .toPromise();
+        .limit(2));
 
       expect(result.length).toEqual(2);
     });
 
     it("should return all items when limit is higher than total of results", async () => {
-      const result = await fileset
+      const result = await lastValueFrom(fileset
         .select()
-        .limit(10)
-        .toPromise();
+        .limit(10));
 
       expect(result.length).toEqual(testData.length);
     });
 
     it(`should split results when setting limit/offset`, async () => {
       const limit = 2;
-      const result = await fileset
+      const result = await lastValueFrom(fileset
         .select()
         .limit(limit)
-        .offset(1)
-        .toPromise();
+        .offset(1));
 
       const expectedSchema = Joi
         .array()
@@ -484,10 +478,9 @@ describe("filter records REST API", () => {
     async function testSorting(fn: "sortAsc" | "sortDesc", sortFn: (a: any, b: any) => number) {
       sortField = faker.random.arrayElement([FIELD.STRING, FIELD.INTEGER]);
 
-      const result = await fileset
+      const result = await lastValueFrom(fileset
         .select()
-        [fn](sortField)
-        .toPromise();
+        [fn](sortField));
 
       const orderedSchemas = testData
         .slice(0) // copy array

--- a/e2e/stories/jfs/jfs-update.e2e.ts
+++ b/e2e/stories/jfs/jfs-update.e2e.ts
@@ -1,3 +1,4 @@
+import { lastValueFrom } from 'rxjs';
 import * as faker from "faker";
 import * as Joi from "joi";
 import { field } from "../../../src";
@@ -24,16 +25,14 @@ describe("update record REST API", async () => {
   it("should return array of records when updating single record by id", async () => {
     const newName = faker.lorem.sentence(3);
 
-    const record = await fileset
+    const record = await lastValueFrom(fileset
       .upload([{
         data: { [DEFAULT_DATASET.FIELD]: faker.name.findName() },
-      }])
-      .toPromise();
+      }]));
 
-    const updateResult = await fileset
+    const updateResult = await lastValueFrom(fileset
       .update({ [DEFAULT_DATASET.FIELD]: newName })
-      .where(field("id").isEqualTo(record.id))
-      .toPromise();
+      .where(field("id").isEqualTo(record.id)));
 
     joiAssert(updateResult, Joi.array()
       .items(FilesetRecordSchema.append({
@@ -48,22 +47,20 @@ describe("update record REST API", async () => {
     const randomField = faker.random.arrayElement(["some_field", "another_field", "last_field"]);
     const newRandomValue = faker.lorem.sentence(5);
 
-    await fileset
+    await lastValueFrom(fileset
       .upload([ {
         data: {
           [DEFAULT_DATASET.FIELD]: originalName,
           [randomField]: faker.lorem.sentence(4),
         },
-      }])
-      .toPromise();
+      }]));
 
-    const updateResult = await fileset
+    const updateResult = await lastValueFrom(fileset
       .update({
         [DEFAULT_DATASET.FIELD]: originalName,
         [randomField]: newRandomValue,
       })
-      .where(field(DEFAULT_DATASET.FIELD).isEqualTo(originalName))
-      .toPromise();
+      .where(field(DEFAULT_DATASET.FIELD).isEqualTo(originalName)));
 
     joiAssert(updateResult, Joi.array()
       .items(FilesetRecordSchema.append({
@@ -77,15 +74,13 @@ describe("update record REST API", async () => {
   it("should throw error under invalid where condition", async () => {
     const originalName = faker.name.findName();
 
-    await fileset
-      .upload([{ data: { [DEFAULT_DATASET.FIELD]: originalName } }])
-      .toPromise();
+    await lastValueFrom(fileset
+      .upload([{ data: { [DEFAULT_DATASET.FIELD]: originalName } }]));
 
     try {
-      await fileset
+      await lastValueFrom(fileset
         .update({ [DEFAULT_DATASET.FIELD]: faker.lorem.sentence(4) })
-        .where(field("id").isEqualTo("invalid"))
-        .toPromise();
+        .where(field("id").isEqualTo("invalid")));
     } catch (e) {
       joiAssert(e, BackendErrorSchema);
     }

--- a/e2e/stories/relations/related.e2e.ts
+++ b/e2e/stories/relations/related.e2e.ts
@@ -1,3 +1,4 @@
+import { lastValueFrom } from 'rxjs';
 import * as faker from "faker";
 import * as Joi from "joi";
 // @ts-ignore
@@ -22,15 +23,14 @@ const testData = [{
 describe("Populate related fields", () => {
   beforeAll(async () => {
     await initForRelations();
-    await dom.dataset("posts").insert(testData).toPromise();
+    await lastValueFrom(dom.dataset("posts").insert(testData));
   });
   afterAll(async () => await cleaning());
 
   it("should select all nested fields by default", async () => {
-    const [{ comments }] = await dom.dataset("posts")
+    const [{ comments }] = await lastValueFrom(dom.dataset("posts")
       .select()
-      .related("comments")
-      .toPromise();
+      .related("comments"));
     joiAssert(comments[0], DatasetRecordSchema.append({
       message: Joi.string().required(),
       like: Joi.boolean().required(),
@@ -38,10 +38,9 @@ describe("Populate related fields", () => {
   });
 
   it("should select only provided fields and id", async () => {
-    const [{ comments }] = await dom.dataset("posts")
+    const [{ comments }] = await lastValueFrom(dom.dataset("posts")
       .select()
-      .related("comments", (c) => c.fields("message"))
-      .toPromise();
+      .related("comments", (c) => c.fields("message")));
 
     joiAssert(comments[0], Joi.object({
       id: Joi.string().uuid().required(),
@@ -50,10 +49,9 @@ describe("Populate related fields", () => {
   });
 
   it("should populate all fields from 2-nd level relation", async () => {
-    const [{ comments }] = await dom.dataset("posts")
+    const [{ comments }] = await lastValueFrom(dom.dataset("posts")
       .select()
-      .related("comments", (c) => c.related("author"))
-      .toPromise();
+      .related("comments", (c) => c.related("author")));
 
     joiAssert(comments[0].author, DatasetRecordSchema.append({
       email: Joi.string().required(),
@@ -61,13 +59,11 @@ describe("Populate related fields", () => {
   });
 
   it("should select only provided fields and id from the 2-nd level relation", async () => {
-    const [{ comments }] = await dom.dataset("posts")
+    const [{ comments }] = await lastValueFrom(dom.dataset("posts")
       .select()
       .related("comments",
         (c) => c.related("author",
-          (author) => author.fields("email")),
-      )
-      .toPromise();
+          (author) => author.fields("email"))));
 
     joiAssert(comments[0].author, Joi.object({
       id: Joi.string().uuid().required(),
@@ -76,16 +72,14 @@ describe("Populate related fields", () => {
   });
 
   it("should select only provided fields and id from both nested relations", async () => {
-    const [{ comments }] = await dom.dataset("posts")
+    const [{ comments }] = await lastValueFrom(dom.dataset("posts")
       .select()
       .related("comments",
         (c) => c
           .fields("message")
           .related("author",
-            (author) => author.fields("email"),
-          ),
-      )
-      .toPromise();
+            (author) => author.fields("email")),
+      ));
 
     joiAssert(comments[0], Joi.object({
       id: Joi.string().uuid().required(),

--- a/e2e/stories/rtc/rtc.e2e.ts
+++ b/e2e/stories/rtc/rtc.e2e.ts
@@ -1,4 +1,4 @@
-import { Subscription } from "rxjs";
+import { lastValueFrom, Subscription } from 'rxjs';
 import { RTCMessageSchema } from "../../lib/rtc";
 import { cleaning, dom, init } from "../../teardowns";
 
@@ -37,9 +37,8 @@ describe("Real Time Communication", () => {
           expect(RTCMessage).toBeDefined();
         });
 
-      const records = await dom.dataset(datasetName)
-        .insert([{test_field: "name"}])
-        .toPromise();
+      const records = await lastValueFrom(dom.dataset(datasetName)
+        .insert([{test_field: "name"}]));
       recordId = records[0].id;
     });
 
@@ -67,13 +66,12 @@ describe("Real Time Communication", () => {
           expect(RTCMessage).toBeDefined();
         });
 
-      const records = await dom.dataset(datasetName)
+      const records = await lastValueFrom(dom.dataset(datasetName)
         .insert([
           { test_field: "name1" },
           { test_field: "name2" },
           { test_field: "name3" },
-        ])
-        .toPromise();
+        ]));
       recordIds = records.map((record) => record.id);
     });
 
@@ -91,9 +89,8 @@ describe("Real Time Communication", () => {
 
     // Insert a record for the updating
     beforeAll(async () => {
-      const records = await dom.dataset(datasetName)
-        .insert([{test_field: "name"}])
-        .toPromise();
+      const records = await lastValueFrom(dom.dataset(datasetName)
+        .insert([{test_field: "name"}]));
       recordId = records[0].id;
     });
 
@@ -111,10 +108,9 @@ describe("Real Time Communication", () => {
           done();
         });
 
-      dom.dataset(datasetName)
+      lastValueFrom(dom.dataset(datasetName)
         .update({test_field: "name_new"})
-        .where((field) => field("id").isEqualTo(recordId))
-        .toPromise();
+        .where((field) => field("id").isEqualTo(recordId)));
     });
 
   });
@@ -123,9 +119,8 @@ describe("Real Time Communication", () => {
 
     // Insert a record for deletion
     beforeAll(async () => {
-      const records = await dom.dataset(datasetName)
-        .insert([{test_field: "name"}])
-        .toPromise();
+      const records = await lastValueFrom(dom.dataset(datasetName)
+        .insert([{test_field: "name"}]));
       recordId = records[0].id;
     });
 
@@ -143,10 +138,9 @@ describe("Real Time Communication", () => {
           done();
         });
 
-      dom.dataset(datasetName)
+      lastValueFrom(dom.dataset(datasetName)
         .delete()
-        .where((field) => field("id").isEqualTo(recordId))
-        .toPromise();
+        .where((field) => field("id").isEqualTo(recordId)));
     });
 
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "jexia-sdk-js",
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
@@ -14,7 +15,7 @@
         "jwt-simple": "^0.5.6",
         "node-fetch": "^2.6.0",
         "reflect-metadata": "^0.1.12",
-        "rxjs": "^6.5.5",
+        "rxjs": "^7.0.0",
         "ws": "^7.3.0"
       },
       "devDependencies": {
@@ -8304,6 +8305,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/inquirer/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
       }
     },
     "node_modules/inquirer/node_modules/strip-ansi": {
@@ -20245,15 +20258,17 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+      "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -22241,7 +22256,8 @@
     "node_modules/tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "node_modules/tslint": {
       "version": "6.1.1",
@@ -31514,6 +31530,15 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -40662,11 +40687,18 @@
       }
     },
     "rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+      "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "safe-buffer": {
@@ -42276,7 +42308,8 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "tslint": {
       "version": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "jwt-simple": "^0.5.6",
     "node-fetch": "^2.6.0",
     "reflect-metadata": "^0.1.12",
-    "rxjs": "^6.5.5",
+    "rxjs": "^7.0.0",
     "ws": "^7.3.0"
   },
   "devDependencies": {

--- a/src/api/core/tokenManager.spec.ts
+++ b/src/api/core/tokenManager.spec.ts
@@ -1,5 +1,5 @@
+import { lastValueFrom, Observable, of, throwError } from 'rxjs';
 import * as faker from "faker";
-import { Observable, of, throwError } from "rxjs";
 import { createMockFor, mockRequestError, validClientOpts } from "../../../spec/testUtils";
 import { MESSAGE, getProjectId, APIKEY_DEFAULT_ALIAS } from "../../config";
 import { RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
@@ -476,7 +476,7 @@ describe("TokenManager", () => {
     it("should dispatch an event when the token got refreshed", async () => {
       const { subject, validOptions, dispatcherMock } = createSubject();
       await subject.init(validOptions);
-      await (subject as any).refresh().toPromise();
+      await lastValueFrom((subject as any).refresh());
       expect(dispatcherMock.emit).toHaveBeenCalledWith(DispatchEvents.TOKEN_REFRESH);
     });
 

--- a/src/api/core/tokenManager.ts
+++ b/src/api/core/tokenManager.ts
@@ -1,5 +1,5 @@
+import { lastValueFrom, from, Observable, iif, of } from 'rxjs';
 import { Injectable, InjectionToken } from "injection-js";
-import { from, Observable, iif, of } from "rxjs";
 import { catchError, map, tap, switchMap, finalize } from "rxjs/operators";
 import { API, MESSAGE, getApiUrl, getProjectId, APIKEY_DEFAULT_ALIAS } from "../../config";
 import { IRequestError, RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
@@ -166,7 +166,7 @@ export class TokenManager {
     /* if auth is provided */
     if (opts.key && opts.secret) {
       this.initPromise = this.initPromise
-        .then(() => this.login(opts).toPromise())
+        .then(() => lastValueFrom(this.login(opts)))
         .then(() => this);
     }
 

--- a/src/api/fileops/fileset.ts
+++ b/src/api/fileops/fileset.ts
@@ -181,6 +181,9 @@ export class Fileset<FormDataType extends IFormData<F>, T, D, F> implements IRes
       )),
       tap(() => {
         if (filesCompleted === filesUploaded) {
+          /* TODO: JSFix could not patch the breaking change:
+          Calling .next on a Subject without passing a value is no longer allowed 
+          Suggested fix: Pass undefined to preserve old behavior. */
           allFilesCompleted.next();
           allFilesCompleted.complete();
         }

--- a/src/api/realtime/realTimeModule.spec.ts
+++ b/src/api/realtime/realTimeModule.spec.ts
@@ -1,6 +1,6 @@
+import { lastValueFrom, of, throwError } from 'rxjs';
 import * as faker from "faker";
 import { ReflectiveInjector } from "injection-js";
-import { of, throwError } from "rxjs";
 import { createMockFor, SpyObj, validClientOpts } from "../../../spec/testUtils";
 import { RequestExecuter } from "../../../src/internal/executer";
 import { MESSAGE, getRtcUrl } from "../../config";
@@ -55,7 +55,7 @@ describe("Real Time Module", () => {
       async moduleConnect() {
         await subject.init(injectorMock);
         const promise = (subject as any).connect();
-        tokenManagerMock.token().toPromise().then(() => webSocketMock.onopen && webSocketMock.onopen({}));
+        lastValueFrom(tokenManagerMock.token()).then(() => webSocketMock.onopen && webSocketMock.onopen({}));
         return promise;
       },
       dispatcherMock,
@@ -247,7 +247,7 @@ describe("Real Time Module", () => {
       await moduleConnect();
       expect(websocket.start).toHaveBeenCalledWith(webSocketMock, jasmine.any(Function), false);
       const token = (websocket.start as jasmine.Spy).calls.mostRecent().args[1]();
-      expect(token).toStrictEqual(tokenManagerMock.token().toPromise());
+      expect(token).toStrictEqual(lastValueFrom(tokenManagerMock.token()));
     });
 
     it("should not start dataset watch functionality if not initialized", async () => {
@@ -306,7 +306,7 @@ describe("Real Time Module", () => {
       const { subject, webSocketMock, tokenManagerMock, injectorMock } = createSubject();
       await subject.init(injectorMock);
       const initPromise = (subject as any).connect();
-      tokenManagerMock.token().toPromise().then(() => webSocketMock.onerror("webSocketError"));
+      lastValueFrom(tokenManagerMock.token()).then(() => webSocketMock.onerror("webSocketError"));
       try {
         await initPromise;
         throw new Error(shouldHaveFailed);

--- a/src/api/realtime/realTimeModule.ts
+++ b/src/api/realtime/realTimeModule.ts
@@ -1,6 +1,6 @@
+import { lastValueFrom, of } from 'rxjs';
 import { ReflectiveInjector } from "injection-js";
 import { catchError, filter, tap } from "rxjs/operators";
-import { of } from "rxjs";
 import { MESSAGE, getRtcUrl } from "../../config";
 import { RequestExecuter } from "../../internal/executer";
 import { IModule, ModuleConfiguration } from "../core/module";
@@ -216,7 +216,7 @@ export class RealTimeModule implements IModule {
    * @internal
    */
   private refreshToken(): void {
-    websocket.refreshToken(this.websocket, () => this.tokenManager.token().toPromise());
+    websocket.refreshToken(this.websocket, () => lastValueFrom(this.tokenManager.token()));
   }
 
   /**
@@ -245,7 +245,7 @@ export class RealTimeModule implements IModule {
     }
 
     // TODO Get rid of promises
-    return this.tokenManager.token().toPromise().then((token) => {
+    return lastValueFrom(this.tokenManager.token()).then((token) => {
       try {
         this.websocket = this.websocketBuilder(getRtcUrl(config, token));
       } catch (error) {
@@ -266,7 +266,7 @@ export class RealTimeModule implements IModule {
         this.websocket.onerror = () => reject(new Error(MESSAGE.RTC.CONNECTION_FAILED));
       });
     })
-      .then(() => websocket.start(this.websocket, () => this.tokenManager.token().toPromise(), reconnection));
+      .then(() => websocket.start(this.websocket, () => lastValueFrom(this.tokenManager.token()), reconnection));
   }
 
   /**

--- a/src/api/realtime/watch.spec.ts
+++ b/src/api/realtime/watch.spec.ts
@@ -1,3 +1,4 @@
+import { lastValueFrom } from 'rxjs';
 // tslint:disable:max-line-length
 import { Subscription } from "rxjs/internal/Subscription";
 import { combineLatest } from "rxjs/operators";
@@ -302,7 +303,7 @@ describe("Dataset Watch", () => {
           createResponseCommandMessage({request, error: realtimeError})), 10);
 
         try {
-          await sub.toPromise();
+          await lastValueFrom(sub);
           throw new Error(shouldHaveFailed);
         } catch (error) {
           expect(error.message).toContain(realtimeError.code);

--- a/src/api/ums/umsModule.spec.ts
+++ b/src/api/ums/umsModule.spec.ts
@@ -1,7 +1,7 @@
+import { lastValueFrom, of } from 'rxjs';
 // tslint:disable:no-string-literal
 import * as faker from "faker";
 import { ReflectiveInjector } from "injection-js";
-import { of } from "rxjs";
 import { createMockFor, SpyObj } from "../../../spec/testUtils";
 import { API, getApiUrl, MESSAGE } from "../../config";
 import { RequestExecuter } from "../../internal/executer";
@@ -315,7 +315,7 @@ describe("UMS Module", () => {
 
           systemDefer.resolve();
           await init();
-          await subject.signIn({ ...user, alias }).toPromise();
+          await lastValueFrom(subject.signIn({ ...user, alias }));
 
           const { calls: [ [tokenManagerAliases] ] } = tokenManagerMock.addTokens.mock;
 
@@ -328,7 +328,7 @@ describe("UMS Module", () => {
 
         systemDefer.resolve();
         await init();
-        await subject.signIn(user).toPromise();
+        await lastValueFrom(subject.signIn(user));
 
         expect(dispatcherMock.emit).toHaveBeenCalledWith(DispatchEvents.UMS_LOGIN);
       });
@@ -361,7 +361,7 @@ describe("UMS Module", () => {
 
           systemDefer.resolve();
           await init();
-          await subject.signIn({ ...oAuthOptions, alias }).toPromise();
+          await lastValueFrom(subject.signIn({ ...oAuthOptions, alias }));
 
           const { calls: [ [tokenManagerAliases] ] } = tokenManagerMock.addTokens.mock;
           expect(tokenManagerAliases).toEqual(aliases);
@@ -373,7 +373,7 @@ describe("UMS Module", () => {
       const { subject, user, systemDefer, init, userResponse } = createSubject();
       systemDefer.resolve();
       await init();
-      const response = await subject.signIn(user).toPromise();
+      const response = await lastValueFrom(subject.signIn(user));
 
       expect(response).toEqual(userResponse);
     });


### PR DESCRIPTION
This pull request was created using the JSFix tool (https://jsfix.live) by Coana.tech (https://coana.tech).
The JSFix run was completed by [mtorp](https://github.com/mtorp).
It bumps rxjs to version 7.0.0.



<details>
<summary>List of breaking changes where JSFix patched all occurrences.</summary>

* toPromise: toPromise return type now returns T | undefined in TypeScript, which is correct, but may break builds.
  - [e2e/stories/jfs/jfs-delete.e2e.ts#L24-L28](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-30323d13dbfaf80764d340e1e6c812203e7e774cbbb2ffc9f71666a887529f86L24-L28)
  - [e2e/stories/jfs/jfs-delete.e2e.ts#L32-L35](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-30323d13dbfaf80764d340e1e6c812203e7e774cbbb2ffc9f71666a887529f86L32-L35)
  - [e2e/stories/jfs/jfs-delete.e2e.ts#L37-L40](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-30323d13dbfaf80764d340e1e6c812203e7e774cbbb2ffc9f71666a887529f86L37-L40)
  - [e2e/stories/jfs/jfs-delete.e2e.ts#L59-L62](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-30323d13dbfaf80764d340e1e6c812203e7e774cbbb2ffc9f71666a887529f86L59-L62)
  - [e2e/stories/jfs/jfs-delete.e2e.ts#L64-L67](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-30323d13dbfaf80764d340e1e6c812203e7e774cbbb2ffc9f71666a887529f86L64-L67)
  - [e2e/stories/jfs/jfs-delete.e2e.ts#L75-L78](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-30323d13dbfaf80764d340e1e6c812203e7e774cbbb2ffc9f71666a887529f86L75-L78)
  - [e2e/stories/jfs/jfs-update.e2e.ts#L27-L31](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-fe858624258c901d05f27aa3ab6392a95b088da07e22c7cd73bee5914e1645beL27-L31)
  - [e2e/stories/jfs/jfs-update.e2e.ts#L33-L36](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-fe858624258c901d05f27aa3ab6392a95b088da07e22c7cd73bee5914e1645beL33-L36)
  - [e2e/stories/jfs/jfs-update.e2e.ts#L51-L58](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-fe858624258c901d05f27aa3ab6392a95b088da07e22c7cd73bee5914e1645beL51-L58)
  - [e2e/stories/jfs/jfs-update.e2e.ts#L60-L66](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-fe858624258c901d05f27aa3ab6392a95b088da07e22c7cd73bee5914e1645beL60-L66)
  - [e2e/stories/dataset/aggregations.e2e.ts#L24-L24](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-149284a2e9fc9ec7cb90d2594f92c65bede604c2e80199c9222f63a2b0971b64L24-L24)
  - [e2e/stories/relations/related.e2e.ts#L25-L25](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f993debf272299df935781323f822f53b5027f84734025f0aa6eeea28cdbaf3fL25-L25)
  - [e2e/stories/relations/related.e2e.ts#L30-L33](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f993debf272299df935781323f822f53b5027f84734025f0aa6eeea28cdbaf3fL30-L33)
  - [e2e/stories/relations/related.e2e.ts#L41-L44](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f993debf272299df935781323f822f53b5027f84734025f0aa6eeea28cdbaf3fL41-L44)
  - [e2e/stories/dataset/output-record.e2e.ts#L63-L65](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-b297943ac9a50609dda081d7f648583d3da0cbea7bd05ba2d191645a87212df6L63-L65)
  - [e2e/stories/jfs/jfs-select.e2e.ts#L28-L31](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f4cb351e25d2309e53428641b656273a04f3230a440702b130e1f3c24ff251c8L28-L31)
  - [e2e/stories/jfs/jfs-select.e2e.ts#L40-L43](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f4cb351e25d2309e53428641b656273a04f3230a440702b130e1f3c24ff251c8L40-L43)
  - [e2e/stories/jfs/jfs-select.e2e.ts#L51-L53](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f4cb351e25d2309e53428641b656273a04f3230a440702b130e1f3c24ff251c8L51-L53)
  - [e2e/stories/jfs/jfs-select.e2e.ts#L57-L60](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f4cb351e25d2309e53428641b656273a04f3230a440702b130e1f3c24ff251c8L57-L60)
  - [e2e/stories/jfs/jfs-select.e2e.ts#L418-L421](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f4cb351e25d2309e53428641b656273a04f3230a440702b130e1f3c24ff251c8L418-L421)
  - [e2e/stories/jfs/jfs-select.e2e.ts#L427-L430](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f4cb351e25d2309e53428641b656273a04f3230a440702b130e1f3c24ff251c8L427-L430)
  - [e2e/stories/jfs/jfs-select.e2e.ts#L437-L441](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f4cb351e25d2309e53428641b656273a04f3230a440702b130e1f3c24ff251c8L437-L441)
  - [e2e/stories/jfs/jfs-select.e2e.ts#L487-L490](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f4cb351e25d2309e53428641b656273a04f3230a440702b130e1f3c24ff251c8L487-L490)
  - [src/api/realtime/realTimeModule.ts#L219-L219](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-7977dd2d56c63ba2efe55f397eb1ac3df301c1f7060255fc621ae1e844687e61L219-L219)
  - [src/api/realtime/realTimeModule.ts#L248-L248](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-7977dd2d56c63ba2efe55f397eb1ac3df301c1f7060255fc621ae1e844687e61L248-L248)
  - [src/api/realtime/realTimeModule.ts#L269-L269](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-7977dd2d56c63ba2efe55f397eb1ac3df301c1f7060255fc621ae1e844687e61L269-L269)
  - [e2e/stories/jfs/jfs-update.e2e.ts#L80-L82](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-fe858624258c901d05f27aa3ab6392a95b088da07e22c7cd73bee5914e1645beL80-L82)
  - [e2e/stories/jfs/jfs-update.e2e.ts#L85-L88](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-fe858624258c901d05f27aa3ab6392a95b088da07e22c7cd73bee5914e1645beL85-L88)
  - [src/api/core/tokenManager.spec.ts#L479-L479](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-4de4c24424459a366d6aa696b98ce77a32fe1d3197465f508a38c693f5078cecL479-L479)
  - [src/api/core/tokenManager.ts#L169-L169](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-2db3c6c6e7b46d075f36356df33e116714fc22ef894522126afb2c4d6a23a8f2L169-L169)
  - [src/api/realtime/watch.spec.ts#L305-L305](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-08d475edadb6ba9ca6f12b418325114a76b72b032ceaa2a08430acedd146d268L305-L305)
  - [src/api/ums/umsModule.spec.ts#L318-L318](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-da5343a3096200f73f3ce4286bbcb3b3767cfe9c46eb01b1a7df5260a8b05251L318-L318)
  - [src/api/ums/umsModule.spec.ts#L331-L331](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-da5343a3096200f73f3ce4286bbcb3b3767cfe9c46eb01b1a7df5260a8b05251L331-L331)
  - [src/api/ums/umsModule.spec.ts#L364-L364](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-da5343a3096200f73f3ce4286bbcb3b3767cfe9c46eb01b1a7df5260a8b05251L364-L364)
  - [src/api/ums/umsModule.spec.ts#L376-L376](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-da5343a3096200f73f3ce4286bbcb3b3767cfe9c46eb01b1a7df5260a8b05251L376-L376)
  - [e2e/stories/relations/attach-detach.e2e.ts#L32-L35](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L32-L35)
  - [e2e/stories/relations/attach-detach.e2e.ts#L50-L50](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L50-L50)
  - [e2e/stories/relations/attach-detach.e2e.ts#L51-L51](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L51-L51)
  - [e2e/stories/relations/attach-detach.e2e.ts#L52-L52](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L52-L52)
  - [e2e/stories/relations/attach-detach.e2e.ts#L69-L72](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L69-L72)
  - [e2e/stories/relations/attach-detach.e2e.ts#L77-L80](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L77-L80)
  - [e2e/stories/relations/attach-detach.e2e.ts#L83-L86](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L83-L86)
  - [e2e/stories/relations/attach-detach.e2e.ts#L88-L91](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L88-L91)
  - [e2e/stories/relations/attach-detach.e2e.ts#L113-L116](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L113-L116)
  - [e2e/stories/relations/attach-detach.e2e.ts#L131-L134](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L131-L134)
  - [e2e/stories/relations/attach-detach.e2e.ts#L161-L161](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L161-L161)
  - [e2e/stories/relations/attach-detach.e2e.ts#L162-L162](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L162-L162)
  - [e2e/stories/relations/attach-detach.e2e.ts#L166-L169](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L166-L169)
  - [e2e/stories/relations/attach-detach.e2e.ts#L183-L186](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L183-L186)
  - [e2e/stories/relations/attach-detach.e2e.ts#L188-L191](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L188-L191)
  - [e2e/stories/relations/attach-detach.e2e.ts#L204-L207](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L204-L207)
  - [e2e/stories/relations/attach-detach.e2e.ts#L210-L213](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L210-L213)
  - [e2e/stories/relations/attach-detach.e2e.ts#L215-L218](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L215-L218)
  - [e2e/stories/relations/attach-detach.e2e.ts#L233-L236](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-33be338306f8c878f693e3aff7a1ee50f00efbae1f7e1110a8f0c6f088b6af31L233-L236)
  - [e2e/stories/relations/related.e2e.ts#L53-L56](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f993debf272299df935781323f822f53b5027f84734025f0aa6eeea28cdbaf3fL53-L56)
  - [e2e/stories/relations/related.e2e.ts#L64-L70](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f993debf272299df935781323f822f53b5027f84734025f0aa6eeea28cdbaf3fL64-L70)
  - [e2e/stories/relations/related.e2e.ts#L79-L88](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f993debf272299df935781323f822f53b5027f84734025f0aa6eeea28cdbaf3fL79-L88)
  - [e2e/stories/rtc/rtc.e2e.ts#L40-L42](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-cb87f33e2344f283ad09541a52876f22e28a6b153323873e800007c77068e7fcL40-L42)
  - [e2e/stories/rtc/rtc.e2e.ts#L70-L76](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-cb87f33e2344f283ad09541a52876f22e28a6b153323873e800007c77068e7fcL70-L76)
  - [e2e/stories/rtc/rtc.e2e.ts#L94-L96](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-cb87f33e2344f283ad09541a52876f22e28a6b153323873e800007c77068e7fcL94-L96)
  - [e2e/stories/rtc/rtc.e2e.ts#L114-L117](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-cb87f33e2344f283ad09541a52876f22e28a6b153323873e800007c77068e7fcL114-L117)
  - [e2e/stories/rtc/rtc.e2e.ts#L126-L128](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-cb87f33e2344f283ad09541a52876f22e28a6b153323873e800007c77068e7fcL126-L128)
  - [e2e/stories/rtc/rtc.e2e.ts#L146-L149](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-cb87f33e2344f283ad09541a52876f22e28a6b153323873e800007c77068e7fcL146-L149)
  - [src/api/realtime/realTimeModule.spec.ts#L58-L58](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-e759c52ba91aeb12c4e2c4910569f57e4e36a67a2b333c555bf45c07e9c92876L58-L58)
  - [src/api/realtime/realTimeModule.spec.ts#L250-L250](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-e759c52ba91aeb12c4e2c4910569f57e4e36a67a2b333c555bf45c07e9c92876L250-L250)
  - [src/api/realtime/realTimeModule.spec.ts#L309-L309](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-e759c52ba91aeb12c4e2c4910569f57e4e36a67a2b333c555bf45c07e9c92876L309-L309)</details>

<details>
<summary>List of breaking changes where JSFix found that there were no occurrences.</summary>

* Subscription: add no longer returns an unnecessary Subscription reference. This was done to prevent confusion caused by a legacy behavior. You can now add and remove functions and Subscriptions as teardowns to and from a Subscription using add and remove directly. Before this, remove only accepted subscriptions.
* Subscriber: new Subscriber no longer takes 0-3 arguments. To create a Subscriber with 0-3 arguments, use Subscriber.create. However, please note that there is little to no reason that you should be creating Subscriber references directly, and Subscriber.create and new Subscriber are both deprecated.
* Leaked implementation detail _unsubscribeAndRecycle of Subscriber has been removed. Just use new Subscription objects
* ReplaySubject no longer schedules emissions when a scheduler is provided. If you need that behavior, please compose in observeOn using pipe, for example: new ReplaySubject(2, 3000).pipe(observeOn(asap))
* rxjs-compat: rxjs/Rx is no longer a valid import site.
* count: No longer passes source observable as a third argument to the predicate. That feature was rarely used, and of limited value. The workaround is to simply close over the source inside of the function if you need to access it in there.
* The static sortActions method on VirtualTimeScheduler is no longer publicly exposed by our TS types.
* Notification.createNext(undefined) will no longer return the exact same reference everytime.
* race: race() will no longer subscribe to subsequent observables if a provided source synchronously errors or completes. This means side effects that might have occurred during subscription in those rare cases will no longer occur.
* unsubscribe no longer available via the this context of observer functions. To reenable, set config.useDeprecatedNextContext = true on the rxjs config found at import { config } from 'rxjs';. Note that enabling this will result in a performance penalty for all consumer subscriptions.
* defer no longer allows factories to return void or undefined. All factories passed to defer must return a proper ObservableInput, such as Observable, Promise, et al. To get the same behavior as you may have relied on previously, return EMPTY or return of() from the factory.
* mergeScan: mergeScan will no longer emit its inner state again upon completion.
* pairs: pairs will no longer function in IE without a polyfill for Object.entries. pairs itself is also deprecated in favor of users just using from(Object.entries(obj)).
* An undocumented behavior where passing a negative count argument to repeat would result in an observable that repeats forever.
* Removed an undocumented behavior where passing a negative count argument to retry would result in an observable that repeats forever.
* single operator will now throw for scenarios where values coming in are either not present, or do not match the provided predicate. Error types have thrown have also been updated, please check documentation for changes.
* skipLast: skipLast will no longer error when passed a negative number, rather it will simply return the source, as though 0 was passed.
* take and will now throw runtime error for arguments that are negative or NaN, this includes non-TS calls like take().
* takeLast now has runtime assertions that throw TypeErrors for invalid arguments. Calling takeLast without arguments or with an argument that is NaN will throw a TypeError
* zip: zip operators will no longer iterate provided iterables "as needed", instead the iterables will be treated as push-streams just like they would be everywhere else in RxJS. This means that passing an endless iterable will result in the thread locking up, as it will endlessly try to read from that iterable. This puts us in-line with all other Rx implementations. To work around this, it is probably best to use map or some combination of map and zip. For example, zip(source$, iterator) could be source$.pipe(map(value => [value, iterator.next().value])).
* zip: Zipping a single array will now have a different result. This is an extreme corner-case, because it is very unlikely that anyone would want to zip an array with nothing at all. The workaround would be to wrap the array in another array zip([[1,2,3]]). But again, that's pretty weird.
* ajax body serialization will now use default XHR behavior in all cases. If the body is a Blob, ArrayBuffer, any array buffer view (like a byte sequence, e.g. Uint8Array, etc), FormData, URLSearchParams, string, or ReadableStream, default handling is use. If the body is otherwise typeof "object", then it will be converted to JSON via JSON.stringify, and the Content-Type header will be set to application/json;charset=utf-8. All other types will emit an error.
* The Content-Type header passed to ajax configuration no longer has any effect on the serialization behavior of the AJAX request.
* ajax: In an extreme corner-case... If an error occurs, the responseType is "json", we're in IE, and the responseType is not valid JSON, the ajax observable will no longer emit a syntax error, rather it will emit a full AjaxError with more details.
* ajax: Ajax implementation drops support for IE10 and lower. This puts us in-line with other implementations and helps clean up code in this area
</details>

<details>
<summary>List of breaking changes not automatically fixable by JSFix (manual review before merge is recommended).</summary><blockquote>

<details open>
<summary>General breaking changes (not related to specific API usages in your code).</summary>

* onUnhandledError: Errors that occur during setup of an observable subscription, after the subscription has emitted an error, or completed will now throw in their own call stack. Before it would call console.warn. This is potentially breaking in edge cases for node applications, which may be configured to terminate for unhandled exceptions. In the unlikely event this affects you, you can configure the behavior to console.warn in the new configuration setting like so: import { config } from 'rxjs'; config.onUnhandledError = (err) => console.warn(err);
* TS: RxJS requires TS 4.2
* RxJS Error types Tests that are written with naive expectations against errors may fail now that errors have a proper stack property. In some testing frameworks, a deep equality check on two error instances will check the values in stack, which could be different.
</details>



<details open>
<summary>The following breaking changes must be patched manually.</summary>

* Calling .next on a Subject without passing a value is no longer allowed
  - [src/api/fileops/fileset.ts#L184-L184](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-973f9d0abeffc275c882039d89afd62a08dc33580d94666939dd6b57586fe7a9L184-L184)</details>



<details open>
<summary>The following breaking changes are unlikely to affect your code. Below each bullet is listed the dependency usages detected by JSFix that may be affected by the breaking change.</summary>

* map: thisArg will now default to undefined. The previous default of MapSubscriber never made any sense. This will only affect code that calls map with a function and references this like so: source.pipe(map(function () { console.log(this); })). There wasn't anything useful about doing this, so the breakage is expected to be very minimal. If anything we're no longer leaking an implementation detail.
  - [src/internal/requestAdapter.ts#L65-L77](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-85df47ad51adb0fab827b0fc0d4c98940bf83bff5b16b6c855116df65b35d38aL65-L77)
  - [src/api/core/tokenManager.ts#L127-L127](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-2db3c6c6e7b46d075f36356df33e116714fc22ef894522126afb2c4d6a23a8f2L127-L127)
  - [src/api/core/tokenManager.ts#L133-L139](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-2db3c6c6e7b46d075f36356df33e116714fc22ef894522126afb2c4d6a23a8f2L133-L139)
  - [src/api/fileops/fileUploader.ts#L56-L56](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-a064cde2e35ec843df3ab80da0aa803f4333fbe637ea76e434bbe28051eaa2d1L56-L56)
  - [src/api/fileops/fileset.ts#L173-L180](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-973f9d0abeffc275c882039d89afd62a08dc33580d94666939dd6b57586fe7a9L173-L180)
  - [src/api/ums/umsModule.ts#L108-L111](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-3d98ce81bdc7c8e5473d32b45625d1985bc1dae601cf079707000df78ab46fe7L108-L111)
  - [src/api/ums/umsModule.ts#L168-L168](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-3d98ce81bdc7c8e5473d32b45625d1985bc1dae601cf079707000df78ab46fe7L168-L168)
  - [src/api/ums/umsModule.ts#L175-L175](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-3d98ce81bdc7c8e5473d32b45625d1985bc1dae601cf079707000df78ab46fe7L175-L175)
  - [src/internal/executer.ts#L34-L45](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-f25b6cf2a3523b663b81f36e9aa42550feacb04cbd7b5b747cccdac197d01a93L34-L45)<br><br>
* throwError: In an extreme corner case for usage, throwError is no longer able to emit a function as an error directly. If you need to push a function as an error, you will have to use the factory function to return the function like so: throwError(() => functionToEmit), in other words throwError(() => () => console.log('called later')).
  - [src/api/core/queries/baseQuery.spec.ts#L27-L27](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-fefb02e099e627fd40d99d99c5c88837271902bac2006b194d4f78da4d99dca3L27-L27)
  - [src/api/core/tokenManager.spec.ts#L127-L129](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-4de4c24424459a366d6aa696b98ce77a32fe1d3197465f508a38c693f5078cecL127-L129)
  - [src/api/core/tokenManager.spec.ts#L141-L141](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-4de4c24424459a366d6aa696b98ce77a32fe1d3197465f508a38c693f5078cecL141-L141)
  - [src/api/core/tokenManager.spec.ts#L150-L152](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-4de4c24424459a366d6aa696b98ce77a32fe1d3197465f508a38c693f5078cecL150-L152)
  - [src/api/core/tokenManager.spec.ts#L455-L455](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-4de4c24424459a366d6aa696b98ce77a32fe1d3197465f508a38c693f5078cecL455-L455)
  - [src/api/core/tokenManager.spec.ts#L499-L499](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-4de4c24424459a366d6aa696b98ce77a32fe1d3197465f508a38c693f5078cecL499-L499)
  - [src/api/core/tokenManager.spec.ts#L516-L516](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-4de4c24424459a366d6aa696b98ce77a32fe1d3197465f508a38c693f5078cecL516-L516)
  - [spec/testUtils.ts#L39-L39](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-eaf7ef4a3f5bdb2ee97e9a4717a2308e91ff1cd0bf7f982e71d5712a62525c73L39-L39)
  - [src/api/realtime/realTimeModule.spec.ts#L99-L99](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-e759c52ba91aeb12c4e2c4910569f57e4e36a67a2b333c555bf45c07e9c92876L99-L99)
  - [src/api/realtime/realTimeModule.spec.ts#L294-L294](https://github.com/mtorp/jexia-sdk-js/pull/1/commits/9dd192a66095dc68b6eb6973d10a4d30d0846468#diff-e759c52ba91aeb12c4e2c4910569f57e4e36a67a2b333c555bf45c07e9c92876L294-L294)</details>

</details>

If you would like to provide feedback to the JSFix developers, then please leave a comment on this pull request.